### PR TITLE
Add details to error messages

### DIFF
--- a/src/textlint-rule-en-max-word-count.js
+++ b/src/textlint-rule-en-max-word-count.js
@@ -64,7 +64,8 @@ function report(context, options = {}) {
                 if (words.length > maxWordCount) {
                     // get original index value of sentence.loc.start
                     const originalIndex = source.originalIndexFromPosition(sentence.loc.start);
-                    const ruleError = new RuleError(`Exceeds the maximum word count of ${maxWordCount}.`, {
+                    const sentenceFragment = `${words.slice(0,3).join(' ')} ...`;
+                    const ruleError = new RuleError(`Maximum word count (${maxWordCount}) exceeded (${words.length}) by "${sentenceFragment}".`, {
                         index: originalIndex
                     });
                     report(node, ruleError);

--- a/test/textlint-rule-en-max-word-count-test.js
+++ b/test/textlint-rule-en-max-word-count-test.js
@@ -20,7 +20,7 @@ tester.run("max-word-count", rule, {
             }
         },
         {
-            text: `
+            text: `## Multiline test
 
 ### JMS Messaging Properties
 
@@ -53,7 +53,7 @@ The URL of the JMS broker.
             },
             errors: [
                 {
-                    message: "Exceeds the maximum word count of 3.",
+                    message: `Maximum word count (3) exceeded (4) by "This is a ...".`,
                     line: 1,
                     column: 1
                 }
@@ -62,19 +62,19 @@ The URL of the JMS broker.
         // multiple match in multiple lines
         {
             text: `This is a pen.
-            
+
 This is not a pen.`,
             options: {
                 max: 3
             },
             errors: [
                 {
-                    message: "Exceeds the maximum word count of 3.",
+                    message: `Maximum word count (3) exceeded (4) by "This is a ...".`,
                     line: 1,
                     column: 1
                 },
                 {
-                    message: "Exceeds the maximum word count of 3.",
+                    message: `Maximum word count (3) exceeded (5) by "This is not ...".`,
                     line: 3,
                     column: 1
                 }
@@ -88,12 +88,12 @@ This is not a pen.`,
             },
             errors: [
                 {
-                    message: "Exceeds the maximum word count of 3.",
+                    message: `Maximum word count (3) exceeded (4) by "This is a ...".`,
                     line: 1,
                     column: 1
                 },
                 {
-                    message: "Exceeds the maximum word count of 3.",
+                    message: `Maximum word count (3) exceeded (5) by "This is not ...".`,
                     line: 1,
                     column: 15
                 }
@@ -107,7 +107,7 @@ This is not a pen.`,
             },
             errors: [
                 {
-                    message: "Exceeds the maximum word count of 3.",
+                    message: `Maximum word count (3) exceeded (9) by "This is a ...".`,
                     line: 1,
                     column: 1
                 }


### PR DESCRIPTION
Add some details to the error messages provided. This should make it easier to read the linter output.

I also added `## Multiline test` to the start of the big test case so that it's easier to read the output of `npm test` which was a bit confusing at first.